### PR TITLE
Fix calibration path type check

### DIFF
--- a/garak/analyze/calibration.py
+++ b/garak/analyze/calibration.py
@@ -130,9 +130,7 @@ class Calibration:
             self.calibration_filename = self._build_path("calibration.json")
 
         else:
-            if not isinstance(calibration_path, str) or isinstance(
-                calibration_path, pathlib.Path
-            ):
+            if not isinstance(calibration_path, (str, pathlib.Path)):
                 raise ValueError("calibration_path must be a string or Path")
             self.calibration_filename = calibration_path
 


### PR DESCRIPTION
## Summary
- allow pathlib.Path instances in Calibration initialization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6853aa3b6b788333840fb871d69d9b3b